### PR TITLE
Potential fix for code scanning alert no. 6: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -56,6 +56,9 @@ jobs:
 
   # On closed events clean up any leftover Restyled PRs
   restyled-cleanup:
+    permissions:
+      contents: read
+      pull-requests: write
     if: ${{ github.event.action == 'closed' }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/android-messages-desktop/security/code-scanning/6](https://github.com/LanikSJ/android-messages-desktop/security/code-scanning/6)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for each job. For the `restyled-cleanup` job, the `contents: read` and `pull-requests: write` permissions are sufficient to perform the cleanup tasks. Adding this block ensures that the `GITHUB_TOKEN` has restricted access, adhering to the principle of least privilege.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
