### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/restyled.yml
+++ b/.github/workflows/restyled.yml
@@ -1,5 +1,9 @@
 name: Restyled
 
+permissions:
+  contents: read
+  pull-requests: write
+
 on:
   pull_request:
     types:


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/android-messages-desktop/security/code-scanning/5](https://github.com/LanikSJ/android-messages-desktop/security/code-scanning/5)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the actions used in the workflow, the following permissions are needed:
- `contents: read` for accessing repository contents.
- `pull-requests: write` for creating and managing pull requests.

The `permissions` block will be added at the root level to apply to all jobs in the workflow. If any job requires additional or fewer permissions, we can override the permissions at the job level.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
