### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -3,6 +3,9 @@
 
 name: pull request
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     types: [opened, synchronize, reopened, edited]


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/android-messages-desktop/security/code-scanning/2](https://github.com/LanikSJ/android-messages-desktop/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will define the least privileges required for the workflow to function correctly. Based on the actions used in the workflow, the `contents: read` permission is sufficient. This ensures that the `GITHUB_TOKEN` has only read access to the repository contents, reducing the risk of unauthorized modifications.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
