### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,10 @@
 
 name: main
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches: [main]


### PR DESCRIPTION
Potential fix for [https://github.com/LanikSJ/android-messages-desktop/security/code-scanning/1](https://github.com/LanikSJ/android-messages-desktop/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. This block should specify the minimal permissions required for the workflow to function correctly. Based on the workflow's operations, the following permissions are appropriate:
- `contents: read` for accessing repository contents.
- `packages: write` for publishing artifacts.

The `permissions` block can be added at the root level of the workflow to apply to all jobs or within the `build` job to limit permissions to that specific job.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
