### PR TITLE
Remove yarn install from GitHub Actions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -67,8 +67,6 @@ jobs:
         name: Install Linux Dependencies
         if: (startsWith(matrix.os, 'ubuntu'))
 
-      - run: yarn install --frozen-lockfile
-
       - name: Build and publish
         run: pnpm run dist --publish onTagOrDraft
         env:


### PR DESCRIPTION
- Remove `yarn` since we're using `pnpm` now