### PR TITLE
Update GitHub Actions workflow to publish artifacts on tag or draft

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
         if: (startsWith(matrix.os, 'ubuntu'))
 
       - name: Build and Publish Artifacts
-        run: pnpm run dist
+        run: pnpm run dist --publish onTagOrDraft
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
- Modified the build command in the GitHub Actions workflow to include the `--publish onTagOrDraft` flag, ensuring artifacts are published when a tag or draft is created.
- This change enhances the deployment process by automating artifact publication for relevant events.
