### PR TITLE
chore(config): migrate markdownlint and prettier configs to TOML

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,7 +1,0 @@
-{
-  "default": true,
-  "MD013": {
-    "line_length": 120
-  },
-  "MD041": false
-}

--- a/.markdownlint.toml
+++ b/.markdownlint.toml
@@ -1,0 +1,6 @@
+default = true
+
+[MD013]
+line_length = 120
+
+MD041 = false

--- a/.prettierrc.js
+++ b/.prettierrc.js
@@ -1,4 +1,0 @@
-export default {
-  trailingComma: "es5",
-  arrowParens: "always",
-};

--- a/.prettierrc.toml
+++ b/.prettierrc.toml
@@ -1,0 +1,4 @@
+arrowParens = "always"
+proseWrap = "never"
+trailingComma = "none"
+useTabs = true


### PR DESCRIPTION
Migrates configuration files for markdownlint and Prettier to TOML format while adjusting Prettier formatting rules.

- Converts `.markdownlint.json` to `.markdownlint.toml`
- Converts `.prettierrc.js` to `.prettierrc.toml`
- Updates Prettier rules to use tabs and disable trailing commas
