### PR TITLE
style(editorconfig): add tab width, max line length, and file patterns

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,13 +1,20 @@
-# editorconfig.org
+# http://editorconfig.org
 root = true
 
 [*]
 indent_style = space
 indent_size = 2
+tab_width = 2
 end_of_line = lf
 charset = utf-8
 trim_trailing_whitespace = true
 insert_final_newline = true
+max_line_length = 140
 
-[*.md]
-trim_trailing_whitespace = false
+[*.{js,ts,jsx,tsx,json,md}]
+indent_style = space
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2


### PR DESCRIPTION
- set tab_width to 2 and max_line_length to 140
- expand markdown pattern to include common code files
- add yaml configuration with space indentation
