### PR TITLE
feat(tray): add constants for tray avatar size and snippet truncation

### DIFF
--- a/src/helpers/constants.ts
+++ b/src/helpers/constants.ts
@@ -17,6 +17,13 @@ export const SETTINGS_FILE = (): string => {
   return path.resolve(app.getPath("userData"), `settings.json`);
 };
 
+// Tray
+/**
+ * Logical size (in points) that recent-conversation avatars are resized to in
+ * the tray menu so every row has a uniform, compact height.
+ */
+export const TRAY_AVATAR_SIZE = 28;
+
 // UUID
 /**
  * An arbitrary v4 uuid generated on https://www.uuidgenerator.net/version4

--- a/src/helpers/trayManager.ts
+++ b/src/helpers/trayManager.ts
@@ -13,6 +13,7 @@ import {
   IS_MAC,
   IS_WINDOWS,
   RESOURCES_PATH,
+  TRAY_AVATAR_SIZE,
   UUID_NAMESPACE,
 } from "./constants";
 import { settings } from "./settings";
@@ -100,7 +101,9 @@ export class TrayManager {
           image != null &&
           image != INITIAL_ICON_IMAGE &&
           showIconsInRecentConversationTrayEnabled.value
-            ? nativeImage.createFromDataURL(image)
+            ? nativeImage
+                .createFromDataURL(image)
+                .resize({ width: TRAY_AVATAR_SIZE, height: TRAY_AVATAR_SIZE })
             : undefined;
 
         return {

--- a/src/preload/constants_preload.ts
+++ b/src/preload/constants_preload.ts
@@ -4,4 +4,8 @@ export const IS_MAC = window.navigator.userAgent.includes("Macintosh");
 
 export const RECENT_CONVERSATION_TRAY_COUNT = 3;
 
+// Max characters of a conversation snippet shown in the tray before it is
+// truncated with an ellipsis.
+export const RECENT_CONVERSATION_SNIPPET_LENGTH = 30;
+
 export { INITIAL_ICON_IMAGE } from "../helpers/constants_shared";

--- a/src/preload/observers.ts
+++ b/src/preload/observers.ts
@@ -1,5 +1,8 @@
 import { ipcRenderer } from "electron";
-import { RECENT_CONVERSATION_TRAY_COUNT } from "./constants_preload";
+import {
+  RECENT_CONVERSATION_SNIPPET_LENGTH,
+  RECENT_CONVERSATION_TRAY_COUNT,
+} from "./constants_preload";
 
 function unreadObserver() {
   if (document.querySelector(".unread") != null) {
@@ -42,12 +45,16 @@ export function recentThreadObserver() {
 
     const image = canvas?.toDataURL();
 
+    const snippet = conversation
+      .querySelector(
+        "a div.text-content div.snippet-text mws-conversation-snippet span"
+      )
+      ?.textContent?.trim();
+
     const recentMessage =
-      conversation
-        .querySelector(
-          "a div.text-content div.snippet-text mws-conversation-snippet span"
-        )
-        ?.textContent?.slice(0, 20) + "...";
+      snippet && snippet.length > RECENT_CONVERSATION_SNIPPET_LENGTH
+        ? `${snippet.slice(0, RECENT_CONVERSATION_SNIPPET_LENGTH).trimEnd()}…`
+        : snippet;
 
     const focusFunction = (): undefined => {
       const element = conversation.querySelector("a");


### PR DESCRIPTION
- Add TRAY_AVATAR_SIZE constant to ensure uniform avatar sizing in tray menu.
- Add RECENT_CONVERSATION_SNIPPET_LENGTH constant to properly truncate conversation snippets with ellipsis when exceeding the max length.

Ref: https://github.com/LanikSJ/android-messages-desktop/commit/7bf6574c5cce33d5d40cdf82f3a98fed96b395c1
