### PR TITLE
feat(electron): add spell check toggle setting

### DIFF
--- a/src/background.ts
+++ b/src/background.ts
@@ -11,8 +11,15 @@ import { Conversation, TrayManager } from "./helpers/trayManager";
 import { popupContextMenu } from "./menu/contextMenu";
 import fs from "fs";
 
-const { autoHideMenuEnabled, trayEnabled, savedWindowSize, savedWindowPosition, checkForUpdateOnLaunchEnabled, taskbarFlashEnabled } =
-  settings;
+const {
+  autoHideMenuEnabled,
+  trayEnabled,
+  savedWindowSize,
+  savedWindowPosition,
+  checkForUpdateOnLaunchEnabled,
+  taskbarFlashEnabled,
+  spellCheckEnabled
+} = settings;
 
 let mainWindow: BrowserWindow;
 let trayManager: TrayManager;
@@ -94,6 +101,9 @@ if (gotTheLock) {
     settings.showIconsInRecentConversationTrayEnabled.subscribe(() => {
       trayManager.refreshTrayMenu();
     });
+
+    // Apply the spell-check preference on launch and whenever it is toggled.
+    spellCheckEnabled.subscribe((enabled) => mainWindow.webContents.session.setSpellCheckerEnabled(enabled));
 
     let quitViaContext = false;
     app.on("before-quit", () => {

--- a/src/helpers/settings.ts
+++ b/src/helpers/settings.ts
@@ -56,6 +56,7 @@ export interface JsonSettings {
   showIconsInRecentConversationTrayEnabled: boolean;
   taskbarFlashEnabled: boolean;
   trayIconRedDotEnabled: boolean;
+  spellCheckEnabled: boolean;
 }
 
 // wraps json settings in the setting type for export
@@ -76,7 +77,8 @@ const defaultSettings: JsonSettings = {
   monochromeIconEnabled: true,
   showIconsInRecentConversationTrayEnabled: true,
   taskbarFlashEnabled: true,
-  trayIconRedDotEnabled: true
+  trayIconRedDotEnabled: true,
+  spellCheckEnabled: true
 };
 
 // create default settings file if it doesnt exist

--- a/src/menu/settingsMenu.ts
+++ b/src/menu/settingsMenu.ts
@@ -13,7 +13,8 @@ const {
   monochromeIconEnabled,
   showIconsInRecentConversationTrayEnabled,
   trayIconRedDotEnabled,
-  taskbarFlashEnabled
+  taskbarFlashEnabled,
+  spellCheckEnabled
 } = settings;
 
 export const settingsMenu: MenuItemConstructorOptions = {
@@ -109,6 +110,13 @@ export const settingsMenu: MenuItemConstructorOptions = {
       click: (item) => {
         taskbarFlashEnabled.next(item.checked);
       }
+    },
+    {
+      id: "spellCheckEnabledMenuItem",
+      label: "Enable Spell Checking",
+      type: "checkbox",
+      checked: spellCheckEnabled.value,
+      click: (item) => spellCheckEnabled.next(item.checked)
     },
     separator,
     {

--- a/src/menu/settingsMenu.ts
+++ b/src/menu/settingsMenu.ts
@@ -116,8 +116,7 @@ export const settingsMenu: MenuItemConstructorOptions = {
       label: "Enable Spell Checking",
       type: "checkbox",
       checked: spellCheckEnabled.value,
-      click: (item) => spellCheckEnabled.next(item.checked)
-    },
+      click: (item) => { spellCheckEnabled.next(item.checked); }    },
     separator,
     {
       id: "checkForUpdateOnLaunchEnabledMenuItem",


### PR DESCRIPTION
- Add spellCheckEnabled setting to JsonSettings interface and defaults
- Subscribe to spellCheckEnabled in background.ts to apply preference on launch and when toggled
- Add "Enable Spell Checking" checkbox menu item in Settings menu

https://github.com/OrangeDrangon/android-messages-desktop/pull/587
