### PR TITLE
chore(ci): bump Node.js to 26 and pnpm to 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
       - tsconfig.json
       - webpack.config.ts
   pull_request:
-    types: [ opened, synchronize, reopened, edited ]
+    types: [opened, synchronize, reopened, edited]
     paths:
       - .github/workflows/ci.yml
       - src/**
@@ -49,8 +49,8 @@ jobs:
           - ubuntu-latest
 
     env:
-      NODE_VERSION: 24
-      PNPM_VERSION: 10
+      NODE_VERSION: 26
+      PNPM_VERSION: 11
 
     steps:
       - name: Checkout
@@ -73,12 +73,9 @@ jobs:
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update -y
-          sudo apt-get install --no-install-recommends -y \
-            libopenjp2-tools \
-            rpm \
-            libarchive-tools
+        run: >-
+          sudo apt-get update -y &&
+          sudo apt-get install --no-install-recommends -y libopenjp2-tools rpm libarchive-tools
 
       - name: Install Dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,8 +37,8 @@ jobs:
           - ubuntu-latest
 
     env:
-      NODE_VERSION: 24
-      PNPM_VERSION: 10
+      NODE_VERSION: 26
+      PNPM_VERSION: 11
 
     steps:
       - name: Checkout


### PR DESCRIPTION
- Upgrade runtime versions for CI and release workflows.
- Simplify Install Linux Dependencies step by chaining commands into single line.
- Fix minor formatting in pull_request event types.
