### PR TITLE
ci: clean lockfile before install to avoid frozen lockfile issues

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,7 +78,9 @@ jobs:
           sudo apt-get install --no-install-recommends -y libopenjp2-tools rpm libarchive-tools
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm clean --lockfile
+          pnpm install --no-frozen-lockfile
 
       - name: Build Packages
         run: pnpm run dist --publish never

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,9 @@ jobs:
             libarchive-tools
 
       - name: Install Dependencies
-        run: pnpm install --frozen-lockfile
+        run: |
+          pnpm clean --lockfile
+          pnpm install --no-frozen-lockfile
 
       - name: Publish Packages
         run: pnpm run dist --publish always


### PR DESCRIPTION
- In both CI and release workflows, replace `pnpm install --frozen-lockfile` with a two-step process: 
- First clean the lockfile using `pnpm clean --lockfile`, then install with `--no-frozen-lockfile`.
- This prevents issues where a stale or inconsistent lockfile causes the frozen install to fail.
