### PR TITLE
chore: disable trimming of trailing whitespace in editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,7 +7,7 @@ indent_size = 2
 tab_width = 2
 end_of_line = lf
 charset = utf-8
-trim_trailing_whitespace = true
+trim_trailing_whitespace = false
 insert_final_newline = true
 max_line_length = 140
 


### PR DESCRIPTION
- prevent last line from getting cut every time you save javascript files
