### PR TITLE
ci: use setup-node action for pnpm setup and fix node-version variable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,9 +65,10 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
       - name: Setup pnpm
         uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,7 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
+          cache: npm
 
       - name: Setup pnpm
         run: npm install -g pnpm@${{ env.PNPM_VERSION }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,8 @@ jobs:
       - name: Setup pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate && pnpm -v
+          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
+          echo "pnpm version: $(pnpm -v)"
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,7 +67,7 @@ jobs:
       - name: Setup pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
+          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate && pnpm -v
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,11 +59,14 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Set up pnpm
+      - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: ${{ env.PNPM_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
+
+      - name: Setup pnpm
+        run: npm install -g pnpm@${{ env.PNPM_VERSION }}
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,10 +63,11 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: npm
 
       - name: Setup pnpm
-        run: npm install -g pnpm@${{ env.PNPM_VERSION }}
+        run: |
+          corepack enable
+          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     paths:
       - .github/workflows/ci.yml
       - src/**
-      - electron-builder.js
+      - electron-builder.config.js
       - package.json
       - pnpm-lock.yaml
       - pnpm-workspace.yaml
@@ -18,7 +18,7 @@ on:
     paths:
       - .github/workflows/ci.yml
       - src/**
-      - electron-builder.js
+      - electron-builder.config.js
       - package.json
       - pnpm-lock.yaml
       - pnpm-workspace.yaml

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,12 +59,15 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          version: ${{ env.PNPM_VERSION }}
-          run_install: true
-          cache: true
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,8 @@ jobs:
         uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
         with:
           version: ${{ env.PNPM_VERSION }}
-          run_install: false
+          run_install: true
+          cache: true
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,13 +59,10 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Setup pnpm
-        run: npm install -g pnpm@${{ env.PNPM_VERSION }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Set up pnpm
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ env.PNPM_VERSION }}
           cache: pnpm
 
       - name: Install Linux Dependencies

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -39,9 +39,10 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
 
       - name: Refresh Lockfile
         run: |

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -41,7 +41,8 @@ jobs:
       - name: Setup pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate && pnpm -v
+          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
+          echo "pnpm version: $(pnpm -v)"
 
       - name: Refresh Lockfile
         run: |

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Setup pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
+          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate && pnpm -v
 
       - name: Refresh Lockfile
         run: |

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -37,7 +37,8 @@ jobs:
         uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
         with:
           version: ${{ env.PNPM_VERSION }}
-          run_install: false
+          run_install: true
+          cache: true
 
       - name: Refresh Lockfile
         run: |

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -33,12 +33,15 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          version: ${{ env.PNPM_VERSION }}
-          run_install: true
-          cache: true
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
 
       - name: Refresh Lockfile
         run: |

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -37,7 +37,7 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
+          cache: npm
 
       - name: Setup pnpm
         run: npm install -g pnpm@${{ env.PNPM_VERSION }}

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -33,13 +33,10 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Setup pnpm
-        run: npm install -g pnpm@${{ env.PNPM_VERSION }}
-
-      - name: Setup Node.js
-        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+      - name: Set up pnpm
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: ${{ env.NODE_VERSION }}
+          node-version: ${{ env.PNPM_VERSION }}
           cache: pnpm
 
       - name: Refresh Lockfile

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -37,10 +37,11 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: npm
 
       - name: Setup pnpm
-        run: npm install -g pnpm@${{ env.PNPM_VERSION }}
+        run: |
+          corepack enable
+          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
 
       - name: Refresh Lockfile
         run: |

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -33,11 +33,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
       - name: Setup pnpm
         uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
         with:

--- a/.github/workflows/refresh-lockfile.yml
+++ b/.github/workflows/refresh-lockfile.yml
@@ -33,11 +33,14 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Set up pnpm
+      - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: ${{ env.PNPM_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
+
+      - name: Setup pnpm
+        run: npm install -g pnpm@${{ env.PNPM_VERSION }}
 
       - name: Refresh Lockfile
         run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: pnpm
+          cache: npm
 
       - name: Setup pnpm
         run: npm install -g pnpm@${{ env.PNPM_VERSION }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Setup pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
+          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate && pnpm -v
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,9 +5,9 @@ on:
     tags:
       - "[0-9]+.[0-9]+.[0-9]+"
     paths:
-      - .github/workflows/ci.yml
+      - .github/workflows/release.yml
       - src/**
-      - electron-builder.js
+      - electron-builder.config.js
       - package.json
       - pnpm-lock.yaml
       - pnpm-workspace.yaml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,12 +47,15 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+      - name: Setup Node.js
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          version: ${{ env.PNPM_VERSION }}
-          run_install: true
-          cache: true
+          node-version: ${{ env.NODE_VERSION }}
+
+      - name: Setup pnpm
+        run: |
+          corepack enable
+          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,10 +51,11 @@ jobs:
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: ${{ env.NODE_VERSION }}
-          cache: npm
 
       - name: Setup pnpm
-        run: npm install -g pnpm@${{ env.PNPM_VERSION }}
+        run: |
+          corepack enable
+          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,11 +47,14 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Set up pnpm
+      - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: ${{ env.PNPM_VERSION }}
+          node-version: ${{ env.NODE_VERSION }}
           cache: pnpm
+
+      - name: Setup pnpm
+        run: npm install -g pnpm@${{ env.PNPM_VERSION }}
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -55,7 +55,8 @@ jobs:
       - name: Setup pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate && pnpm -v
+          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
+          echo "pnpm version: $(pnpm -v)"
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,9 +53,10 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
 
       - name: Setup pnpm
-        run: |
-          corepack enable
-          corepack prepare pnpm@${{ env.PNPM_VERSION }} --activate
+        uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
+        with:
+          version: ${{ env.PNPM_VERSION }}
+          run_install: false
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,8 +47,11 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Setup pnpm
-        run: npm install -g pnpm@${{ env.PNPM_VERSION }}
+      - name: Set up pnpm
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: ${{ env.PNPM_VERSION }}
+          cache: pnpm
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,11 +47,6 @@ jobs:
           persist-credentials: false
           fetch-depth: 1
 
-      - name: Setup Node.js
-        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
-        with:
-          node-version: ${{ env.NODE_VERSION }}
-
       - name: Setup pnpm
         uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,8 @@ jobs:
         uses: pnpm/action-setup@008330803749db0355799c700092d9a85fd074e9 # v6.0.9
         with:
           version: ${{ env.PNPM_VERSION }}
-          run_install: false
+          run_install: true
+          cache: true
 
       - name: Install Linux Dependencies
         if: runner.os == 'Linux'


### PR DESCRIPTION
- Replace the manual pnpm installation with the `actions/setup-node` action, which now supports pnpm caching.
- Also correct the `node-version` input from `NODE_VERSION` to the intended `PNPM_VERSION` in all workflow files.
